### PR TITLE
Compatibility with forwarded requests

### DIFF
--- a/app/code/local/Alanstormdotcom/Layoutviewer/Model/Observer.php
+++ b/app/code/local/Alanstormdotcom/Layoutviewer/Model/Observer.php
@@ -16,15 +16,19 @@
 		//entry point
 		public function checkForLayoutDisplayRequest($observer) {			
 			$this->init();
-			$is_set = array_key_exists(self::FLAG_SHOW_LAYOUT, $_GET);
-			if(		$is_set && 'package' == $_GET[self::FLAG_SHOW_LAYOUT]) {
-				$this->outputPackageLayout();
-			}
-			else if($is_set && 'page'    == $_GET[self::FLAG_SHOW_LAYOUT]) {
-				$this->outputPageLayout();			
-			}
-			else if($is_set && 'handles' == $_GET[self::FLAG_SHOW_LAYOUT]) {
-				$this->outputHandles();
+			/** @var Mage_Core_Controller_Varien_Action $controllerAction */
+			$controllerAction = $observer->getEvent()->getData('controller_action');
+			if ($controllerAction->getRequest()->isDispatched()) {
+				$is_set = array_key_exists(self::FLAG_SHOW_LAYOUT, $_GET);
+				if(		$is_set && 'package' == $_GET[self::FLAG_SHOW_LAYOUT]) {
+					$this->outputPackageLayout();
+				}
+				else if($is_set && 'page'    == $_GET[self::FLAG_SHOW_LAYOUT]) {
+					$this->outputPageLayout();			
+				}
+				else if($is_set && 'handles' == $_GET[self::FLAG_SHOW_LAYOUT]) {
+					$this->outputHandles();
+				}
 			}
 		}
 


### PR DESCRIPTION
Alan — no idea if you still maintain this old gem but I still use it :)
The current version sends empty output for requests that are using _forward() internally, as it calls die() before the second request can be processed and the layout loaded. This PR fixes that by waiting until the request is dispatched.
