### PR TITLE
Add layout source file tagging on nodes, enable module by default, etc ...

### DIFF
--- a/app/code/local/Alanstormdotcom/Layoutviewer/Model/Layout/Update.php
+++ b/app/code/local/Alanstormdotcom/Layoutviewer/Model/Layout/Update.php
@@ -1,4 +1,5 @@
 <?php
+
 /*
 * The MIT License (MIT)
 * 
@@ -22,14 +23,117 @@
 * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 * THE SOFTWARE.
 */
-class Alanstormdotcom_Layoutviewer_Model_Layout_Update extends Mage_Core_Model_Layout_Update {		
+
+class Alanstormdotcom_Layoutviewer_Model_Layout_Update 
+    extends Mage_Core_Model_Layout_Update
+{
+
     //we'll display this request's package layout
     
     //we'll also display this request's "reduced" layout, etc. etc
-    
 
-    public function getPackageLayout() {
+    /**
+     * Collect and merge layout updates from file
+     *
+     * @param string        $area     The system area.
+     * @param string        $package  The design package name.
+     * @param string        $theme    The package theme name.
+     * @param integer|null  $storeId  An optional store ID for context.
+     * 
+     * @return Mage_Core_Model_Layout_Element
+     */
+    public function getFileLayoutUpdatesXml($area, $package, $theme, $storeId = null)
+    {
+        if (null === $storeId) {
+            $storeId = Mage::app()->getStore()->getId();
+        }
+        /* @var $design Mage_Core_Model_Design_Package */
+        $design = Mage::getSingleton('core/design_package');
+        $layoutXml = null;
+        $elementClass = $this->getElementClass();
+        $updatesRoot = Mage::app()->getConfig()->getNode($area.'/layout/updates');
+        Mage::dispatchEvent('core_layout_update_updates_get_after', array('updates' => $updatesRoot));
+
+        /*** Start version compatibility updates ***/
+        $version = Mage::getVersionInfo();
+
+        // Support for CE 1.9 changes for theme fallback
+        if ($version['major'] == 1 && $version['minor'] >= 9) {
+            $updates        = $updatesRoot->asArray();
+            $themeUpdates   = Mage::getSingleton('core/design_config')->getNode("$area/$package/$theme/layout/updates");
+
+            if ($themeUpdates && is_array($themeUpdates->asArray())) {
+                //array_values() to ensure that theme-specific layouts don't override, but add to module layouts
+                $updates = array_merge($updates, array_values($themeUpdates->asArray()));
+            }
+
+            $updateFiles = array();
+
+            foreach ($updates as $updateNode) {
+                if (!empty($updateNode['file'])) {
+                    $module = isset($updateNode['@']['module']) ? $updateNode['@']['module'] : false;
+
+                    if ($module && Mage::getStoreConfigFlag('advanced/modules_disable_output/' . $module, $storeId)) {
+                        continue;
+                    }
+
+                    $updateFiles[] = $updateNode['file'];
+                }
+            }
+        } else { // All other versions (presumably < 1.9 but > 1.3)
+            $updateFiles = array();
+
+            foreach ($updatesRoot->children() as $updateNode) {
+                if ($updateNode->file) {
+                    $module = $updateNode->getAttribute('module');
+
+                    if ($module && Mage::getStoreConfigFlag('advanced/modules_disable_output/' . $module, $storeId)) {
+                        continue;
+                    }
+
+                    $updateFiles[] = (string)$updateNode->file;
+                }
+            }
+        }
+        /*** End version compatibility updates ***/
+
+        // custom local layout updates file - load always last
+        $updateFiles[] = 'local.xml';
+        $layoutStr = '';
+        foreach ($updateFiles as $file) {
+            $filename = $design->getLayoutFilename($file, array(
+                '_area'    => $area,
+                '_package' => $package,
+                '_theme'   => $theme
+            ));
+            if (!is_readable($filename)) {
+                continue;
+            }
+            $fileStr = file_get_contents($filename);
+            $fileStr = str_replace($this->_subst['from'], $this->_subst['to'], $fileStr);
+            $fileXml = simplexml_load_string($fileStr, $elementClass);
+            if (!$fileXml instanceof SimpleXMLElement) {
+                continue;
+            }
+
+            /*** Start attribute injection ***/
+            foreach ($fileXml->children() as $handle) {
+                foreach ($handle->children() as $child) {
+                    $child->addAttribute('x-layout-file', $file);
+                }
+            }
+            /*** End attribute injection ***/
+
+            $layoutStr .= $fileXml->innerXml();
+        }
+        $layoutXml = simplexml_load_string('<layouts>'.$layoutStr.'</layouts>', $elementClass);
+        return $layoutXml;
+    }
+
+    public function getPackageLayout()
+    {
         $this->fetchFileLayoutUpdates();
         return $this->_packageLayout;
-    }		
+    }
+
 }

--- a/app/code/local/Alanstormdotcom/Layoutviewer/etc/config.xml
+++ b/app/code/local/Alanstormdotcom/Layoutviewer/etc/config.xml
@@ -1,34 +1,31 @@
 <?xml version="1.0"?>
-<config>	
-	<modules>
-	<Alanstormdotcom_Layoutviewer>
-		<version>0.1.0</version>
-	</Alanstormdotcom_Layoutviewer></modules>
-
-	<global>
-		<models>
-			<alanstormdotcom_layoutviewer>
-				<class>Alanstormdotcom_Layoutviewer_Model</class>
-			</alanstormdotcom_layoutviewer>
-			
-			<core>
-				<rewrite>
-					<layout_update>Alanstormdotcom_Layoutviewer_Model_Layout_Update</layout_update>
-				</rewrite>
-			</core>
-			
-		</models>
-	
-		<events>
-			<controller_action_postdispatch>
-				<observers>
-					<alanstormdotcom_layoutviewer_model_observer>
-						<type>singleton</type>						
-						<class>Alanstormdotcom_Layoutviewer_Model_Observer</class>
-						<method>checkForLayoutDisplayRequest</method>
-					</alanstormdotcom_layoutviewer_model_observer>
-				</observers>
-			</controller_action_postdispatch>
-		</events>
-	</global>	
+<config>    
+    <modules>
+        <Alanstormdotcom_Layoutviewer>
+            <version>0.1.0</version>
+        </Alanstormdotcom_Layoutviewer>
+    </modules>
+    <global>
+        <models>
+            <alanstormdotcom_layoutviewer>
+                <class>Alanstormdotcom_Layoutviewer_Model</class>
+            </alanstormdotcom_layoutviewer>
+            <core>
+                <rewrite>
+                    <layout_update>Alanstormdotcom_Layoutviewer_Model_Layout_Update</layout_update>
+                </rewrite>
+            </core>
+        </models>
+        <events>
+            <controller_action_postdispatch>
+                <observers>
+                    <alanstormdotcom_layoutviewer_model_observer>
+                        <type>singleton</type>
+                        <class>Alanstormdotcom_Layoutviewer_Model_Observer</class>
+                        <method>checkForLayoutDisplayRequest</method>
+                    </alanstormdotcom_layoutviewer_model_observer>
+                </observers>
+            </controller_action_postdispatch>
+        </events>
+    </global>
 </config>

--- a/app/etc/modules/Alanstormdotcom_Layoutviewer.xml
+++ b/app/etc/modules/Alanstormdotcom_Layoutviewer.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <config>
-	<modules>
-		<Alanstormdotcom_Layoutviewer>
-			<active>false</active>
-			<codePool>local</codePool>
-		</Alanstormdotcom_Layoutviewer>
-	</modules>
+    <modules>
+        <Alanstormdotcom_Layoutviewer>
+            <active>true</active>
+            <codePool>local</codePool>
+        </Alanstormdotcom_Layoutviewer>
+    </modules>
 </config>


### PR DESCRIPTION
A feature I've always wanted when viewing the page layout XML dump is the ability to see source files after the merge. This update re-writes `Mage_Core_Model_Layout_Update::getFileLayoutUpdatesXml` to inject an `x-layout-file` attribute into every child node of each layout file's handles.

This way, I have a better idea of which layout file is actually affecting the page.

This is a tricky method to extend, because there are no convenient dispatch events to hook into my target entry point. So in my best effort I tried to write some compatibility checks that would allow CE versions 1.4 - 1.9 to be supported.

---

Also cleaned up the formatting in config files a bit, and enabled the module by default.

---

If you don't think the main feature belongs in this module, that's OK. I'll just keep using my fork :) But I thought this makes for a good addition, especially since you're already re-writing the layout update model.
